### PR TITLE
Move generation of .crc-exist file to generic code

### DIFF
--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -120,7 +120,10 @@ func (api *Client) Create(h *host.Host) error {
 		return fmt.Errorf("Error creating machine: %s", err)
 	}
 
-	log.Debug("Reticulating splines...")
+	log.Debug("Machine successfully created")
+	if err := api.SetExists(h.Name); err != nil {
+		log.Debug("Failed to record VM existence")
+	}
 
 	return nil
 }

--- a/libmachine/persist/filestore.go
+++ b/libmachine/persist/filestore.go
@@ -96,6 +96,18 @@ func (s Filestore) List() ([]string, error) {
 	return hostNames, nil
 }
 
+func (s Filestore) SetExists(name string) error {
+	filename := filepath.Join(s.GetMachinesDir(), name, fmt.Sprintf(".%s-exist", name))
+	file, err := os.OpenFile(filename, os.O_RDONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	file.Close()
+	log.Debugf("Created %s", filename)
+
+	return nil
+}
+
 func (s Filestore) Exists(name string) (bool, error) {
 	_, err := os.Stat(filepath.Join(s.GetMachinesDir(), name, fmt.Sprintf(".%s-exist", name)))
 	log.Debugf("Checking file: %s", filepath.Join(s.GetMachinesDir(), name, fmt.Sprintf(".%s-exist", name)))

--- a/libmachine/persist/filestore.go
+++ b/libmachine/persist/filestore.go
@@ -109,8 +109,9 @@ func (s Filestore) SetExists(name string) error {
 }
 
 func (s Filestore) Exists(name string) (bool, error) {
-	_, err := os.Stat(filepath.Join(s.GetMachinesDir(), name, fmt.Sprintf(".%s-exist", name)))
-	log.Debugf("Checking file: %s", filepath.Join(s.GetMachinesDir(), name, fmt.Sprintf(".%s-exist", name)))
+	filename := filepath.Join(s.GetMachinesDir(), name, fmt.Sprintf(".%s-exist", name))
+	_, err := os.Stat(filename)
+	log.Debugf("Checking file: %s", filename)
 
 	if os.IsNotExist(err) {
 		return false, nil


### PR DESCRIPTION
Currently, each driver has to do this itself. Better to move that part
to the generic libmachine code to avoid duplication.

This fixes #10
https://github.com/code-ready/machine/issues/10
