### PR TITLE
Fix compilation after d2d48242

### DIFF
--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -118,10 +118,10 @@ func (f *DefaultRPCClientDriverFactory) Close() error {
 	return nil
 }
 
-func (f *DefaultRPCClientDriverFactory) NewRPCClientDriver(driverName string, rawDriver []byte) (*RPCClientDriver, error) {
+func (f *DefaultRPCClientDriverFactory) NewRPCClientDriver(driverName string, driverPath string, rawDriver []byte) (*RPCClientDriver, error) {
 	mcnName := ""
 
-	p, err := localbinary.NewPlugin(driverName)
+	p, err := localbinary.NewPlugin(driverName, driverPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For some reason, 2 hunks got lost in the PR introducing a way for
libmachine users to set the path for machine drivers.
This commit fixes this.
