### PR TITLE
Issue #19: Add bundle name to base driver

### DIFF
--- a/drivers/errdriver/error.go
+++ b/drivers/errdriver/error.go
@@ -76,6 +76,10 @@ func (d *Driver) GetSSHUsername() string {
 	return ""
 }
 
+func (d *Driver) GetBundleName() (string, error) {
+	return "", NotLoadable{d.Name}
+}
+
 func (d *Driver) GetState() (state.State, error) {
 	return state.Error, NotLoadable{d.Name}
 }

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -14,7 +14,7 @@ import (
 type Driver struct {
 	*drivers.BaseDriver
 	CrcDiskCopier        CRCDiskCopier
-	BundlePath           string
+	BundleName           string
 	VirtualSwitch        string
 	DiskPath             string
 	DiskPathUrl          string
@@ -85,7 +85,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 }
 
 func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
-	d.BundlePath = flags.String("hyperv-bundlepath-url")
+	d.BundleName = flags.String("hyperv-bundlepath-url")
 	d.VirtualSwitch = flags.String("hyperv-virtual-switch")
 	d.Memory = flags.Int("hyperv-memory")
 	d.CPU = flags.Int("hyperv-cpu-count")

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -22,7 +22,7 @@ import (
 const (
 	defaultCPU                 = 4
 	defaultMemory              = 8192
-	defaultBundlePath          = ""
+	defaultBundleName          = ""
 	defaultHostOnlyCIDR        = "192.168.99.1/24"
 	defaultHostOnlyNictype     = "82540EM"
 	defaultHostOnlyPromiscMode = "deny"
@@ -43,8 +43,6 @@ var (
 
 type Driver struct {
 	*drivers.BaseDriver
-	// CRC System bundle
-	BundlePath string
 	VBoxManager
 	HostInterfaces
 	logsReader          LogsReader
@@ -124,8 +122,8 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			Name:   "virtualbox-bundlepath-url",
 			Usage:  "The URL of the crc bundlepath. Defaults to the latest available version",
-			Value:  defaultBundlePath,
-			EnvVar: "VIRTUALBOX_BundlePath_URL",
+			Value:  defaultBundleName,
+			EnvVar: "VIRTUALBOX_BundleName_URL",
 		},
 		mcnflag.BoolFlag{
 			Name:   "virtualbox-host-dns-resolver",

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -20,6 +20,7 @@ type BaseDriver struct {
 	SSHPort     int
 	SSHKeyPath  string
 	StorePath   string
+	BundleName  string
 }
 
 // DriverName returns the name of the driver
@@ -78,4 +79,9 @@ func (d *BaseDriver) PreCreateCheck() error {
 // ResolveStorePath returns the store path where the machine is
 func (d *BaseDriver) ResolveStorePath(file string) string {
 	return filepath.Join(d.StorePath, "machines", d.MachineName, file)
+}
+
+// Returns the name of the bundle which was used to create this machine
+func (d* BaseDriver) GetBundleName() (string, error) {
+	return d.BundleName, nil
 }

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -41,6 +41,9 @@ type Driver interface {
 	// GetSSHUsername returns username for use with ssh
 	GetSSHUsername() string
 
+	// GetBundleName() Returns the name of the unpacked bundle which was used to create this machine
+	GetBundleName() (string, error)
+
 	// GetURL returns a Docker compatible host URL for connecting to this host
 	// e.g. tcp://1.2.3.4:2376
 	GetURL() (string, error)

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -74,6 +74,7 @@ const (
 	GetSSHKeyPathMethod      = `.GetSSHKeyPath`
 	GetSSHPortMethod         = `.GetSSHPort`
 	GetSSHUsernameMethod     = `.GetSSHUsername`
+	GetBundleNameMethod      = `.GetBundleName`
 	GetStateMethod           = `.GetState`
 	PreCreateCheckMethod     = `.PreCreateCheck`
 	CreateMethod             = `.Create`
@@ -332,6 +333,10 @@ func (c *RPCClientDriver) GetSSHUsername() string {
 	}
 
 	return username
+}
+
+func (c *RPCClientDriver) GetBundleName() (string, error) {
+	return c.rpcStringCall(GetBundleNameMethod)
 }
 
 func (c *RPCClientDriver) GetState() (state.State, error) {

--- a/libmachine/drivers/rpc/server_driver.go
+++ b/libmachine/drivers/rpc/server_driver.go
@@ -181,6 +181,12 @@ func (r *RPCServerDriver) GetSSHUsername(_ *struct{}, reply *string) error {
 	return nil
 }
 
+func (r *RPCServerDriver) GetBundleName(_ *struct{}, reply *string) error {
+	path, err := r.ActualDriver.GetBundleName()
+	*reply = path
+	return err
+}
+
 func (r *RPCServerDriver) GetURL(_ *struct{}, reply *string) error {
 	info, err := r.ActualDriver.GetURL()
 	*reply = info


### PR DESCRIPTION
Currently hyperv and libvirt have this as a driver specific field, but
this was forgotten in hyperkit. This will be needed to be able to know
which version of CRC is running from a ~/.crc/machines/crc directory.

We limit ourselves to a "BundleName" rather than a "BundePath" as we
cannot rely on files outside of ~/.crc to be untouched by the user (ie
not moved/removed). Since bundles are extracted to
~/.crc/cache/$BundleName, this the name is going to be enough to find
back the bundle content.

https://github.com/code-ready/machine/issues/19

<!--

Thank you for your interest in contributing to Docker Machine!
Please note that the project is now in MAINTENANCE MODE, meaning we will
no longer review or merge PRs that introduce new features, drivers or
provisioners. We will continue to consider and review proposed bug fixes
and dependency upgrades when appropriate.

Thank you for your understanding.

-->

## Description

<!-- In a couple sentences, explain what your PR does and what problem it fixes -->

## Related issue(s)

<!-- Include any issue from the tracker that this PR addresses or otherwise relates to -->
