### PR TITLE
Remove use of removed modules

### DIFF
--- a/libmachine/host/host_test.go
+++ b/libmachine/host/host_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/code-ready/machine/drivers/fakedriver"
 	_ "github.com/code-ready/machine/drivers/none"
-	"github.com/code-ready/machine/libmachine/provision"
 	"github.com/code-ready/machine/libmachine/state"
 )
 
@@ -40,11 +39,6 @@ func TestValidateHostnameInvalid(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	defer provision.SetDetector(&provision.StandardDetector{})
-	provision.SetDetector(&provision.FakeDetector{
-		Provisioner: provision.NewNetstatProvisioner(),
-	})
-
 	host := &Host{
 		Driver: &fakedriver.Driver{
 			MockState: state.Stopped,

--- a/libmachine/host/migrate_v0_v1_test.go
+++ b/libmachine/host/migrate_v0_v1_test.go
@@ -4,14 +4,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/code-ready/machine/commands/mcndirs"
 	"github.com/code-ready/machine/libmachine/auth"
 	"github.com/code-ready/machine/libmachine/engine"
 	"github.com/code-ready/machine/libmachine/swarm"
 )
 
 func TestMigrateHostV0ToV1(t *testing.T) {
-	mcndirs.BaseDir = "/tmp/migration"
 	originalHost := &V0{
 		HostOptions:    nil,
 		SwarmDiscovery: "token://foobar",

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"strconv"
 	"time"
 )
@@ -21,34 +20,6 @@ func (e MultiError) Error() string {
 		aggregate += err.Error() + "\n"
 	}
 	return aggregate
-}
-
-// GetHomeDir returns the home directory
-// TODO: Having this here just strikes me as dangerous, but some of the drivers
-// depend on it ;_;
-func GetHomeDir() string {
-	if runtime.GOOS == "windows" {
-		return os.Getenv("USERPROFILE")
-	}
-	return os.Getenv("HOME")
-}
-
-func GetUsername() string {
-	u := "unknown"
-	osUser := ""
-
-	switch runtime.GOOS {
-	case "darwin", "linux":
-		osUser = os.Getenv("USER")
-	case "windows":
-		osUser = os.Getenv("USERNAME")
-	}
-
-	if osUser != "" {
-		u = osUser
-	}
-
-	return u
 }
 
 func CopyFile(src, dst string) error {

--- a/libmachine/mcnutils/utils_test.go
+++ b/libmachine/mcnutils/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 

--- a/libmachine/mcnutils/utils_test.go
+++ b/libmachine/mcnutils/utils_test.go
@@ -53,21 +53,6 @@ func TestCopyFile(t *testing.T) {
 	}
 }
 
-func TestGetUsername(t *testing.T) {
-	currentUser := "unknown"
-	switch runtime.GOOS {
-	case "darwin", "linux":
-		currentUser = os.Getenv("USER")
-	case "windows":
-		currentUser = os.Getenv("USERNAME")
-	}
-
-	username := GetUsername()
-	if username != currentUser {
-		t.Fatalf("expected username %s; received %s", currentUser, username)
-	}
-}
-
 func TestGenerateRandomID(t *testing.T) {
 	id := GenerateRandomID()
 

--- a/libmachine/persist/filestore_test.go
+++ b/libmachine/persist/filestore_test.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/code-ready/machine/commands/mcndirs"
 	"github.com/code-ready/machine/drivers/none"
 	"github.com/code-ready/machine/libmachine/host"
 	"github.com/code-ready/machine/libmachine/hosttest"
@@ -25,8 +24,6 @@ func getTestStore() Filestore {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-
-	mcndirs.BaseDir = tmpDir
 
 	return Filestore{
 		Path:             tmpDir,


### PR DESCRIPTION
The test files still reference some modules which were removed when
    'machine' was imported in code. This commit removes these, even if the
    tests are not building after all the changes which were made.
    This fixes https://github.com/code-ready/machine/issues/28
