### PR TITLE
Fix HyperV Administrator check

### DIFF
--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -85,7 +85,7 @@ func isAdministrator() (bool, error) {
 }
 
 func isHypervAdministrator() bool {
-	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole("S-1-5-32-578")`)
+	stdout, err := cmdOut(`@([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(([System.Security.Principal.SecurityIdentifier]::new("S-1-5-32-578")))`)
 	if err != nil {
 		log.Debug(err)
 		return false


### PR DESCRIPTION
IsInRole() parameter should be either a group name [String] with potential I18N issues (the group name may change), or an SID [SecurityIdentifier]. Using a SID as a String doesn't work.

