### PR TITLE
Driver type

### DIFF
--- a/drivers/hyperkit/driver_darwin.go
+++ b/drivers/hyperkit/driver_darwin.go
@@ -18,7 +18,6 @@ type Driver struct {
 	VmlinuzPath   string
 	InitrdPath    string
 	KernelCmdLine string
-	SSHKeyPath    string
 	HyperKitPath  string
 }
 

--- a/drivers/hyperkit/driver_darwin.go
+++ b/drivers/hyperkit/driver_darwin.go
@@ -10,9 +10,7 @@ const (
 )
 
 type Driver struct {
-	*drivers.BaseDriver
-	CPU           int
-	Memory        int
+	*drivers.VMDriver
 	Cmdline       string
 	UUID          string
 	VpnKitSock    string
@@ -20,18 +18,19 @@ type Driver struct {
 	VmlinuzPath   string
 	InitrdPath    string
 	KernelCmdLine string
-	DiskPathURL   string
 	SSHKeyPath    string
 	HyperKitPath  string
 }
 
 func NewDriver(hostName, storePath string) *Driver {
 	return &Driver{
-		BaseDriver: &drivers.BaseDriver{
-			MachineName: hostName,
-			StorePath:   storePath,
+		VMDriver: &drivers.VMDriver{
+			BaseDriver: &drivers.BaseDriver{
+				MachineName: hostName,
+				StorePath:   storePath,
+			},
+			Memory: defaultMemory,
+			CPU:    defaultCPU,
 		},
-		Memory: defaultMemory,
-		CPU:    defaultCPU,
 	}
 }

--- a/drivers/hyperkit/driver_darwin.go
+++ b/drivers/hyperkit/driver_darwin.go
@@ -1,0 +1,37 @@
+package hyperkit
+
+import (
+	"github.com/code-ready/machine/libmachine/drivers"
+)
+
+const (
+	defaultMemory = 8192
+	defaultCPU    = 4
+)
+
+type Driver struct {
+	*drivers.BaseDriver
+	CPU           int
+	Memory        int
+	Cmdline       string
+	UUID          string
+	VpnKitSock    string
+	VSockPorts    []string
+	VmlinuzPath   string
+	InitrdPath    string
+	KernelCmdLine string
+	DiskPathURL   string
+	SSHKeyPath    string
+	HyperKitPath  string
+}
+
+func NewDriver(hostName, storePath string) *Driver {
+	return &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+		Memory: defaultMemory,
+		CPU:    defaultCPU,
+	}
+}

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -18,7 +18,6 @@ type Driver struct {
 	DiskPath             string
 	MacAddress           string
 	DisableDynamicMemory bool
-	SSHKeyPath           string
 }
 
 const (

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -12,13 +12,10 @@ import (
 )
 
 type Driver struct {
-	*drivers.BaseDriver
+	*drivers.VMDriver
 	CrcDiskCopier        CRCDiskCopier
 	VirtualSwitch        string
 	DiskPath             string
-	DiskPathUrl          string
-	Memory               int
-	CPU                  int
 	MacAddress           string
 	DisableDynamicMemory bool
 	SSHKeyPath           string
@@ -34,12 +31,14 @@ const (
 func NewDriver(hostName, storePath string) *Driver {
 	return &Driver{
 		CrcDiskCopier:        NewCRCDiskCopier(),
-		Memory:               defaultMemory,
-		CPU:                  defaultCPU,
 		DisableDynamicMemory: defaultDisableDynamicMemory,
-		BaseDriver: &drivers.BaseDriver{
-			MachineName: hostName,
-			StorePath:   storePath,
+		VMDriver: &drivers.VMDriver{
+			BaseDriver: &drivers.BaseDriver{
+				MachineName: hostName,
+				StorePath:   storePath,
+			},
+			Memory: defaultMemory,
+			CPU:    defaultCPU,
 		},
 	}
 }
@@ -171,7 +170,7 @@ func (d *Driver) PreCreateCheck() error {
 }
 
 func (d *Driver) Create() error {
-	if err := d.CrcDiskCopier.CopyDiskToMachineDir(d.StorePath, d.MachineName, d.DiskPathUrl); err != nil {
+	if err := d.CrcDiskCopier.CopyDiskToMachineDir(d.StorePath, d.MachineName, d.DiskPathURL); err != nil {
 		return err
 	}
 

--- a/drivers/libvirt/driver_linux.go
+++ b/drivers/libvirt/driver_linux.go
@@ -5,17 +5,13 @@ import (
 )
 
 type Driver struct {
-	*drivers.BaseDriver
+	*drivers.VMDriver
 
 	// Driver specific configuration
-	Memory      int
-	CPU         int
-	Network     string
-	DiskPath    string
-	CacheMode   string
-	IOMode      string
-	DiskPathURL string
-	SSHKeyPath  string
+	Network   string
+	DiskPath  string
+	CacheMode string
+	IOMode    string
 }
 
 const (
@@ -27,12 +23,14 @@ const (
 
 func NewDriver(hostName, storePath string) *Driver {
 	return &Driver{
-		BaseDriver: &drivers.BaseDriver{
-			MachineName: hostName,
-			StorePath:   storePath,
+		VMDriver: &drivers.VMDriver{
+			BaseDriver: &drivers.BaseDriver{
+				MachineName: hostName,
+				StorePath:   storePath,
+			},
+			Memory: defaultMemory,
+			CPU:    defaultCPU,
 		},
-		Memory:    defaultMemory,
-		CPU:       defaultCPU,
 		CacheMode: defaultCacheMode,
 		IOMode:    defaultIOMode,
 	}

--- a/drivers/libvirt/driver_linux.go
+++ b/drivers/libvirt/driver_linux.go
@@ -1,0 +1,39 @@
+package libvirt
+
+import (
+	"github.com/code-ready/machine/libmachine/drivers"
+)
+
+type Driver struct {
+	*drivers.BaseDriver
+
+	// Driver specific configuration
+	Memory      int
+	CPU         int
+	Network     string
+	DiskPath    string
+	CacheMode   string
+	IOMode      string
+	DiskPathURL string
+	SSHKeyPath  string
+}
+
+const (
+	defaultMemory    = 8192
+	defaultCPU       = 4
+	defaultCacheMode = "default"
+	defaultIOMode    = "threads"
+)
+
+func NewDriver(hostName, storePath string) *Driver {
+	return &Driver{
+		BaseDriver: &drivers.BaseDriver{
+			MachineName: hostName,
+			StorePath:   storePath,
+		},
+		Memory:    defaultMemory,
+		CPU:       defaultCPU,
+		CacheMode: defaultCacheMode,
+		IOMode:    defaultIOMode,
+	}
+}

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -23,6 +23,13 @@ type BaseDriver struct {
 	BundleName  string
 }
 
+type VMDriver struct {
+	*BaseDriver
+	DiskPathURL string
+	Memory      int
+	CPU         int
+}
+
 // DriverName returns the name of the driver
 func (d *BaseDriver) DriverName() string {
 	return "unknown"


### PR DESCRIPTION
Currently, some driver structures are duplicated between machine-driver-xxx and crc, which makes it a bit awkward/error-prone to add/remove fields/... This PR in combination with https://github.com/cfergeau/crc-driver-hyperkit/tree/driver-type https://github.com/cfergeau/machine-driver-libvirt/tree/driver-type and https://github.com/cfergeau/crc/tree/driver-type is an attempt at improving that.
Not fully sure what the best place is for these driver struct, `machine/drivers/xxxx/`, `machine/libmachine/drivers`, some place else?