### PR TITLE
Add vsock option for libvirt driver

### DIFF
--- a/drivers/libvirt/driver_linux.go
+++ b/drivers/libvirt/driver_linux.go
@@ -12,6 +12,7 @@ type Driver struct {
 	DiskPath  string
 	CacheMode string
 	IOMode    string
+	VSock     bool
 }
 
 const (


### PR DESCRIPTION
crc will then be able to activate or not vsock. This is required to keep RHEL7 support.