### PR TITLE
Make VMNet optional

### DIFF
--- a/drivers/hyperkit/driver_darwin.go
+++ b/drivers/hyperkit/driver_darwin.go
@@ -19,6 +19,7 @@ type Driver struct {
 	InitrdPath    string
 	KernelCmdLine string
 	HyperKitPath  string
+	VMNet         bool
 }
 
 func NewDriver(hostName, storePath string) *Driver {


### PR DESCRIPTION
With a tap adapter redirecting traffic to vsock, like VPNKit, it is
possible to not use VMNet.
