### PR TITLE
Improve error handling in ssh NativeClient

### DIFF
--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -181,7 +181,10 @@ func (client *NativeClient) session(command string) (*ssh.Client, *ssh.Session, 
 		return nil, nil, fmt.Errorf("Mysterious error dialing TCP for SSH (we already succeeded at least once) : %s", err)
 	}
 	session, err := conn.NewSession()
-
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, err
+	}
 	return conn, session, err
 }
 

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/code-ready/machine/libmachine/log"
-	"github.com/code-ready/machine/libmachine/mcnutils"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -161,24 +160,10 @@ func NewNativeConfig(user string, auth *Auth) (ssh.ClientConfig, error) {
 	}, nil
 }
 
-func (client *NativeClient) dialSuccess() bool {
-	conn, err := ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), &client.Config)
-	if err != nil {
-		log.Debugf("Error dialing TCP: %s", err)
-		return false
-	}
-	closeConn(conn)
-	return true
-}
-
 func (client *NativeClient) session() (*ssh.Client, *ssh.Session, error) {
-	if err := mcnutils.WaitFor(client.dialSuccess); err != nil {
-		return nil, nil, fmt.Errorf("Error attempting SSH client dial: %s", err)
-	}
-
 	conn, err := ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), &client.Config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Mysterious error dialing TCP for SSH (we already succeeded at least once) : %s", err)
+		return nil, nil, err
 	}
 	session, err := conn.NewSession()
 	if err != nil {

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/code-ready/machine/libmachine/log"
 	"github.com/code-ready/machine/libmachine/mcnutils"
@@ -156,6 +157,7 @@ func NewNativeConfig(user string, auth *Auth) (ssh.ClientConfig, error) {
 		Auth: authMethods,
 		// #nosec G106
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         time.Minute,
 	}, nil
 }
 

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -194,8 +194,10 @@ func (client *NativeClient) Output(command string) (string, error) {
 	defer session.Close()
 
 	output, err := session.CombinedOutput(command)
-
-	return string(output), err
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
 }
 
 func (client *NativeClient) OutputWithPty(command string) (string, error) {

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -191,7 +191,7 @@ func (client *NativeClient) session() (*ssh.Client, *ssh.Session, error) {
 func (client *NativeClient) Output(command string) (string, error) {
 	conn, session, err := client.session()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	defer closeConn(conn)
 	defer session.Close()
@@ -206,7 +206,7 @@ func (client *NativeClient) Output(command string) (string, error) {
 func (client *NativeClient) OutputWithPty(command string) (string, error) {
 	conn, session, err := client.session()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	defer closeConn(conn)
 	defer session.Close()

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -171,7 +171,7 @@ func (client *NativeClient) dialSuccess() bool {
 	return true
 }
 
-func (client *NativeClient) session(command string) (*ssh.Client, *ssh.Session, error) {
+func (client *NativeClient) session() (*ssh.Client, *ssh.Session, error) {
 	if err := mcnutils.WaitFor(client.dialSuccess); err != nil {
 		return nil, nil, fmt.Errorf("Error attempting SSH client dial: %s", err)
 	}
@@ -189,7 +189,7 @@ func (client *NativeClient) session(command string) (*ssh.Client, *ssh.Session, 
 }
 
 func (client *NativeClient) Output(command string) (string, error) {
-	conn, session, err := client.session(command)
+	conn, session, err := client.session()
 	if err != nil {
 		return "", nil
 	}
@@ -204,7 +204,7 @@ func (client *NativeClient) Output(command string) (string, error) {
 }
 
 func (client *NativeClient) OutputWithPty(command string) (string, error) {
-	conn, session, err := client.session(command)
+	conn, session, err := client.session()
 	if err != nil {
 		return "", nil
 	}
@@ -236,7 +236,7 @@ func (client *NativeClient) OutputWithPty(command string) (string, error) {
 }
 
 func (client *NativeClient) Start(command string) (io.ReadCloser, io.ReadCloser, error) {
-	conn, session, err := client.session(command)
+	conn, session, err := client.session()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
* Add 1min timeout for connection, like the ssh command (it was 0)
* Check errors and close connections where needed
* Remove retry loop for connection. It is already done at the upper level most of the time. CRC might need to adapt some timeouts.

My objective: use the same ssh implementation for Linux, macOS and Windows, use the NativeClient.