### PR TITLE
hyperv: Don't try to convert DiskCapacity from GiB to bytes

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -91,10 +91,6 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	return nil
 }
 
-func toBytes(gibibytes uint) string {
-	return fmt.Sprintf("%d", gibibytes*1024*1024*1024)
-}
-
 func (d *Driver) UpdateConfigRaw(rawConfig []byte) error {
 	var newDriver Driver
 
@@ -124,8 +120,8 @@ func (d *Driver) UpdateConfigRaw(rawConfig []byte) error {
 		}
 	}
 	if newDriver.DiskCapacity != d.DiskCapacity {
-		log.Debugf("Resizing disk from %d GiB to %d GiB", d.DiskCapacity, newDriver.DiskCapacity)
-		err := cmd("Hyper-V\\Resize-VHD", "-Path", quote(d.getDiskPath()), "-SizeBytes", toBytes(uint(newDriver.DiskCapacity)))
+		log.Debugf("Resizing disk from %d bytes to %d bytes", d.DiskCapacity, newDriver.DiskCapacity)
+		err := cmd("Hyper-V\\Resize-VHD", "-Path", quote(d.getDiskPath()), "-SizeBytes", fmt.Sprintf("%d", newDriver.DiskCapacity))
 		if err != nil {
 			log.Warnf("Failed to set disk size to %d", newDriver.DiskCapacity)
 			return err

--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -29,7 +29,7 @@ type VMDriver struct {
 	ImageFormat     string
 	Memory          int
 	CPU             int
-	DiskCapacity    uint64
+	DiskCapacity    uint64 // bytes
 }
 
 // DriverName returns the name of the driver


### PR DESCRIPTION
DiskCapacity is already in bytes, so it must not be converted again.