### PR TITLE
Add VpnKit UUID parameter

### DIFF
--- a/drivers/hyperkit/driver_darwin.go
+++ b/drivers/hyperkit/driver_darwin.go
@@ -14,6 +14,7 @@ type Driver struct {
 	Cmdline       string
 	UUID          string
 	VpnKitSock    string
+	VpnKitUUID    string
 	VSockPorts    []string
 	VmlinuzPath   string
 	InitrdPath    string


### PR DESCRIPTION
This is needed in order to use the vpnkit protocol in hyperkit to get a
 static IP address.

---

At the end, the vpnkit protocol allows to remove the vsock container in macOS bundle