### PR TITLE
hyperkit: Add QcowToolPath to shared driver struct

### DIFF
--- a/drivers/hyperkit/driver_darwin.go
+++ b/drivers/hyperkit/driver_darwin.go
@@ -20,6 +20,7 @@ type Driver struct {
 	InitrdPath    string
 	KernelCmdLine string
 	HyperKitPath  string
+	QcowToolPath  string
 	VMNet         bool
 }
 


### PR DESCRIPTION
This will be used for disk resizing on macOS.