### PR TITLE
Remove unused states

### DIFF
--- a/drivers/fakedriver/fakedriver.go
+++ b/drivers/fakedriver/fakedriver.go
@@ -31,9 +31,6 @@ func (d *Driver) GetIP() (string, error) {
 	if d.MockState == state.Error {
 		return "", fmt.Errorf("Unable to get ip")
 	}
-	if d.MockState == state.Timeout {
-		select {} // Loop forever
-	}
 	if d.MockState != state.Running {
 		return "", drivers.ErrHostIsNotRunning
 	}

--- a/libmachine/state/state.go
+++ b/libmachine/state/state.go
@@ -4,27 +4,27 @@ package state
 type State int
 
 const (
-	None State = iota
+	reserved0 State = iota
 	Running
-	Paused
-	Saved
+	reserved2
+	reserved3
 	Stopped
-	Stopping
-	Starting
+	reserved5
+	reserved6
 	Error
-	Timeout
+	reserved8
 )
 
 var states = []string{
-	"",
+	"reserved0",
 	"Running",
-	"Paused",
-	"Saved",
+	"reserved2",
+	"reserved3",
 	"Stopped",
-	"Stopping",
-	"Starting",
+	"reserved5",
+	"reserved6",
 	"Error",
-	"Timeout",
+	"reserved8",
 }
 
 // Given a State type, returns its string representation

--- a/libmachine/state/state_test.go
+++ b/libmachine/state/state_test.go
@@ -5,9 +5,6 @@ import (
 )
 
 func TestDaemonCreate(t *testing.T) {
-	if None.String() != "" {
-		t.Fatal("None state should be empty string")
-	}
 	if Running.String() != "Running" {
 		t.Fatal("Running state should be 'Running'")
 	}


### PR DESCRIPTION
Since state.State is using iota and it used in the driver protocol,
removed states are replaced by placeholders.