### PR TITLE
Follow-up for file sharing

### DIFF
--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -78,5 +78,5 @@ func (d *BaseDriver) UpdateConfigRaw(rawData []byte) error {
 }
 
 func (d *VMDriver) GetSharedDirs() ([]SharedDir, error) {
-	return d.SharedDirs, nil
+	return nil, ErrNotImplemented
 }

--- a/libmachine/drivers/drivers.go
+++ b/libmachine/drivers/drivers.go
@@ -56,6 +56,7 @@ type Driver interface {
 
 var ErrHostIsNotRunning = errors.New("Host is not running")
 var ErrNotImplemented = errors.New("Not Implemented")
+var ErrNotSupported = errors.New("Not Supported")
 
 func MachineInState(d Driver, desiredState state.State) func() bool {
 	return func() bool {


### PR DESCRIPTION
This changes the default implementation of GetSharedDirs() to return an error so that we can get better behaviour for machine drivers which haven't been patched yet to get file sharing support.
This also introduces a new error used to report that the current host does not support file sharing (macOS 11, rhel7, ...)