### PR TITLE
driver/base: Change cpu type as uint and memory uint64

### DIFF
--- a/libmachine/drivers/base.go
+++ b/libmachine/drivers/base.go
@@ -18,8 +18,8 @@ type VMDriver struct {
 	*BaseDriver
 	ImageSourcePath string
 	ImageFormat     string
-	Memory          int
-	CPU             int
+	Memory          uint
+	CPU             uint
 	DiskCapacity    uint64 // bytes
 	SharedDirs      []SharedDir
 }


### PR DESCRIPTION
Those value can't be negative and in our crc codebase it again needs the type coversion for multiple function which cause latest golint to fail with following error
```
pkg/crc/machine/config/driver.go:8:15: G115: integer overflow conversion int -> uint64 (gosec)
	return uint64(gib) * 1024 * 1024 * 1024
	             ^
pkg/crc/validation/validation.go:58:25: G115: integer overflow conversion int -> uint64 (gosec)
	if totalMemory < uint64(valueBytes) {
pkg/drivers/vfkit/driver_darwin.go:177:9: G115: integer overflow conversion int -> uint64 (gosec)
		uint64(d.Memory),
```