### PR TITLE
Replace TCP with Unix sockets for local RPC

### DIFF
--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/rpc"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/crc-org/machine/libmachine/drivers"
@@ -41,12 +42,29 @@ Please use this plugin through the main 'crc' binary.
 	}
 	rpc.HandleHTTP()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	socketDir := os.Getenv("CRC_SOCKET_DIR")
+	if socketDir == "" {
+		socketDir = filepath.Join(os.TempDir(), "crc-machine")
+	}
+
+	if err := os.MkdirAll(socketDir, 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating socket directory: %s\n", err)
+		os.Exit(1)
+	}
+
+	socketPath := filepath.Join(socketDir, "plugin.sock")
+	os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading RPC server: %s\n", err)
 		os.Exit(1)
 	}
 	defer listener.Close()
+	if err := os.Chmod(socketPath, 0600); err != nil {
+		_ = listener.Close()
+		fmt.Fprintf(os.Stderr, "Error setting socket permissions: %s\n", err)
+		os.Exit(1)
+	}
 
 	fmt.Println(listener.Addr())
 

--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -51,6 +51,15 @@ Please use this plugin through the main 'crc' binary.
 		fmt.Fprintf(os.Stderr, "Error creating socket directory: %s\n", err)
 		os.Exit(1)
 	}
+	socketDirInfo, err := os.Stat(socketDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error checking socket directory: %s\n", err)
+		os.Exit(1)
+	}
+	if !socketDirInfo.IsDir() || socketDirInfo.Mode().Perm()&0077 != 0 {
+		fmt.Fprintf(os.Stderr, "Socket directory must be owner-only: %s\n", socketDir)
+		os.Exit(1)
+	}
 
 	socketPath := filepath.Join(socketDir, "plugin.sock")
 	os.Remove(socketPath)

--- a/libmachine/drivers/rpc/client_driver.go
+++ b/libmachine/drivers/rpc/client_driver.go
@@ -128,7 +128,7 @@ func (f *DefaultRPCClientDriverFactory) NewRPCClientDriver(driverName string, dr
 		return nil, fmt.Errorf("Error attempting to get plugin server address for RPC: %s", err)
 	}
 
-	rpcclient, err := rpc.DialHTTP("tcp", addr)
+	rpcclient, err := rpc.DialHTTP("unix", addr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Switch from TCP (127.0.0.1) to Unix domain sockets to restrict RPC access to the socket owner via filesystem permissions. Configurable via CRC_SOCKET_DIR, defaults to /tmp/crc-machine.

### How to test:
1. **Checkout the PR branch**
   ```bash
   git checkout pr/replace-with-unix
   ```

2. **Update machine-driver-libvirt**
   ```bash
   cd ../machine-driver-libvirt
   go mod edit -replace=github.com/crc-org/machine=../machine
   go mod vendor
   make clean
   make local
   cp crc-driver-libvirt-local ~/.crc/bin/crc-driver-libvirt-amd64
   ```

3. **Update CRC**

Apply the following patch in CRC:

```bash
diff --git a/cmd/crc/cmd/root.go b/cmd/crc/cmd/root.go
index 8aefaa9d6..45a53c5b9 100644
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -53,6 +53,8 @@ func init() {
        if err := constants.EnsureBaseDirectoriesExist(); err != nil {
                logging.Fatal(err.Error())
        }
+       // Set the socket directory for machine driver plugins
+       os.Setenv("CRC_SOCKET_DIR", constants.SocketBaseDir)
        var err error
        config, viper, err = newConfig()
        if err != nil {
```
   ```bash
   cd ../crc
   go mod edit -replace=github.com/crc-org/machine=../machine
   go mod vendor
   make clean
   make
   ```

4. **Clean up and start fresh**
   ```bash
   crc stop
   crc delete -f
   crc cleanup
   ```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local driver communication reliability by switching internal RPC connections to use a Unix domain socket instead of TCP.
  * Added safer socket setup by choosing the socket directory from `CRC_SOCKET_DIR` (with a secure default), creating it with owner-only permissions, and enforcing restrictive permissions on the socket file.
  * When setup fails or permissions are incorrect, the service now fails more clearly and avoids starting with unsafe access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->