### PR TITLE
plugin: Use constant for socket dir env var

### DIFF
--- a/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/libmachine/drivers/plugin/localbinary/plugin.go
@@ -26,6 +26,7 @@ const (
 	PluginEnvKey        = "MACHINE_PLUGIN_TOKEN"
 	PluginEnvVal        = "42"
 	PluginEnvDriverName = "MACHINE_PLUGIN_DRIVER_NAME"
+	PluginEnvSocketDir  = "MACHINE_PLUGIN_SOCKET_DIR"
 )
 
 type McnBinaryExecutor interface {

--- a/libmachine/drivers/plugin/register_driver.go
+++ b/libmachine/drivers/plugin/register_driver.go
@@ -68,7 +68,7 @@ Please use this plugin through the main 'crc' binary.
 	}
 	rpc.HandleHTTP()
 
-	socketDir := os.Getenv("CRC_SOCKET_DIR")
+	socketDir := os.Getenv(localbinary.PluginEnvSocketDir)
 	if socketDir == "" {
 		socketDir = filepath.Join(os.TempDir(), "crc-machine")
 	}


### PR DESCRIPTION
This is a follow-up to https://github.com/crc-org/machine/pull/72

The name of the environment variable should be extracted to an exportable constant which can then be imported and used in crc to maintain consistency across the repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin socket configuration now uses the standardized environment variable, improving compatibility when locating local plugin sockets.
  * Existing fallback behavior and socket setup remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->